### PR TITLE
Convert tabs to spaces in features, remove trailing spaces

### DIFF
--- a/features/learner_changes_employer.feature
+++ b/features/learner_changes_employer.feature
@@ -4,7 +4,7 @@ Feature: Provider earnings and payments where a learner changes employers
         Given the apprenticeship funding band maximum is 17000
 
     Scenario: Earnings and payments for a DAS learner, levy available, and there is a change to the Negotiated Cost which happens at the end of the month
-        Given The learner is programme only DAS 
+        Given The learner is programme only DAS
         And the ABC has a levy balance > agreed price for all months
         And the XYZ has a levy balance > agreed price for all months
         And the learner changes employers
@@ -37,7 +37,7 @@ Feature: Provider earnings and payments where a learner changes employers
 
 
     Scenario: Earnings and payments for a DAS learner, levy available, and there is a change to the Negotiated Cost which happens mid month
-        Given The learner is programme only DAS 
+        Given The learner is programme only DAS
         And the ABC has a levy balance > agreed price for all months
         And the XYZ has a levy balance > agreed price for all months
         And the learner changes employers
@@ -70,7 +70,7 @@ Feature: Provider earnings and payments where a learner changes employers
 
 
     Scenario: Earnings and payments for a DAS learner, levy available, and there is a change to the Negotiated Cost earlier than expected
-        Given The learner is programme only DAS 
+        Given The learner is programme only DAS
         And the ABC has a levy balance > agreed price for all months
         And the XYZ has a levy balance > agreed price for all months
         And the learner changes employers
@@ -104,29 +104,29 @@ Feature: Provider earnings and payments where a learner changes employers
 
 
 
-			
+
     Scenario: Earnings and payments for a DAS learner, levy available, where a learner switches from DAS to Non Das employer at the end of month
-        Given The learner is programme only DAS 
+        Given The learner is programme only DAS
         And the ABC has a levy balance > agreed price for all months
-    		
-		And the learner changes employers
+
+        And the learner changes employers
             | Employer | Type    | ILR employment start date |
             | ABC      | DAS     | 03/08/2017                |
             | XYZ      | Non DAS | 03/11/2017                |
-		And the following commitments exist on 03/12/2017:
+        And the following commitments exist on 03/12/2017:
             | Employer | ULN       | price effective date | planned end date | actual end date | agreed price |
             | ABC      | learner a | 03/08/2017           | 04/08/2018       | 02/11/2017      | 15000        |
-         
+
         When an ILR file is submitted on 03/12/2017 with the following data:
             | ULN       | start date | planned end date | actual end date | completion status | Total training price | Total training price effective date | Total assessment price | Total assessment price effective date | Residual training price | Residual training price effective date | Residual assessment price | Residual assessment price effective date |
             | learner a | 03/08/2017 | 04/08/2018       |                 | continuing        | 12000                | 03/08/2017                          | 3000                   | 03/08/2017                            | 4500                    | 03/11/2017                             | 1125                      | 03/11/2017                               |
-       
-	     And the Contract type in the ILR is:
-		    | contract type | date from  | date to    |
-		    | DAS           | 03/08/2017 | 02/11/2017 |
-		    | Non DAS       | 03/11/2017 | 04/08/2018 |
 
-	    Then the data lock status of the ILR in 03/12/2017 is:
+        And the Contract type in the ILR is:
+            | contract type | date from  | date to    |
+            | DAS           | 03/08/2017 | 02/11/2017 |
+            | Non DAS       | 03/11/2017 | 04/08/2018 |
+
+        Then the data lock status of the ILR in 03/12/2017 is:
             | Type                | 08/17 - 10/17 | 11/17 onwards |
             | Matching commitment | ABC           |               |
         And the provider earnings and payments break down as follows:


### PR DESCRIPTION
This change:

- makes the file internally consistent (because it's mostly using spaces)
- fixes indentation to improve readability of the feature file on GitHub